### PR TITLE
[fix][broker] Flaky-test: ExtensibleLoadManagerImplTest.testDisableBroker

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -460,7 +460,10 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             String serviceUnit,
             ServiceUnitState state,
             Optional<String> owner) {
-
+        // If the channel is disabled or closed, this broker cannot be an active owner.
+        if (channelState == Disabled || channelState == Closed) {
+            return CompletableFuture.completedFuture(Optional.empty());
+        }
         // If this broker's registry does not exist(possibly suffering from connecting to the metadata store),
         // we return the owner without its activeness check.
         // This broker tries to serve lookups on a best efforts basis when metadata store connection is unstable.

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/loadbalance/extensions/channel/ServiceUnitStateChannelImpl.java
@@ -460,8 +460,13 @@ public class ServiceUnitStateChannelImpl implements ServiceUnitStateChannel {
             String serviceUnit,
             ServiceUnitState state,
             Optional<String> owner) {
-        // If the channel is disabled or closed, this broker cannot be an active owner.
+        // If the channel is disabled or closed, this broker cannot be the active owner.
+        // If the table already has an owner, and it is not local, return it as is for upper-level redirection;
+        // otherwise, return empty.
         if (channelState == Disabled || channelState == Closed) {
+            if (owner.isPresent() && !isTargetBroker(owner.get())) {
+                return CompletableFuture.completedFuture(owner);
+            }
             return CompletableFuture.completedFuture(Optional.empty());
         }
         // If this broker's registry does not exist(possibly suffering from connecting to the metadata store),


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

**log:** https://gist.github.com/Denovo1998/c48c58c1de0270a4008ae77b6161adfb

- Running the full ExtensibleLoadManagerImplTest occasionally fails at testDisableBroker. After calling disableBroker(), the broker unregisters and the channel cleans ownerships. However, subsequent checkOwnershipAsync/getOwnerAsync against the disabled broker could still trigger a liveness verification on metadata-based table view, which throws a MetadataStoreException (wrapped by ExecutionException), causing flaky failures in full-suite runs.
- Meanwhile, ServiceUnitStateChannelTest has explicit expectations on disabled/closed channels:
  - isOwner should still return true for Owned or Splitting states if the local broker is the designated owner/source,
  - getOwnerAsync should not complete immediately for Assigning (dst=local) or Releasing (dst=local), i.e., the future should remain unfinished to simulate “waiting for ownership”.
- We need to unify the disabled/closed-channel behavior to short-circuit ownership queries without metadata liveness checks, while preserving the above per-state semantics, eliminating flaky behaviors and aligning with test expectations.

### Modifications

- Refined ServiceUnitStateChannelImpl#getActiveOwnerAsync to handle the disabled/closed channel states without performing liveness verification:
  - Owned, Splitting: return the owner (if any) as-is, so isOwner() on a disabled/closed channel remains true when appropriate.
  - Assigning, Releasing:
    - If the dst is the local broker, return an unfinished future (via dedupeGetOwnerRequest) to reflect “waiting for ownership”, matching testActiveGetOwner’s expectation (future is not done).
    - If the dst is another broker, return that broker ID to facilitate upper-layer redirection.
    - If no dst present, return Optional.empty().
  - Other states (Init, Free, Deleted, …): return Optional.empty().
- For non-disabled/closed channels, keep the original behavior unchanged:
  - If the broker registry is not registered:
    - On metadata-based table view, still fail with MetadataStoreException (unchanged).
    - On in-memory table view, return owner directly (unchanged).
  - Otherwise, continue to dedupe and validate liveness using registry.lookupAsync(newOwner) (unchanged).
- This change:
  - Prevents MetadataStoreException in disabled/closed scenarios, so testDisableBroker no longer fails randomly.
  - Keeps isOwner semantics on disabled/closed channels for Owned/Splitting.
  - Keeps Assigning/Releasing(dst=local) getOwnerAsync as an unfinished future, matching test expectations.
  - Does not affect the normal STARTED channel behavior nor the existing metadata-based/in-memory table view behaviors.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/apache/pulsar/pull/24770

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
