### PR TITLE
[fix][test] Stabilize PublishRateLimiterOverconsumingTest by aligning measurement and using adjacent 2-sec averages

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterOverconsumingTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PublishRateLimiterOverconsumingTest.java
@@ -79,7 +79,8 @@ public class PublishRateLimiterOverconsumingTest extends BrokerTestBase {
         int durationSeconds = 5;
         int numberOfConsumers = 5;
         int numberOfProducersWithIndependentClients = 5;
-        int numberOfMessagesForEachProducer = (rateInMsg * (durationSeconds + 1)) / 5;
+        int numberOfMessagesForEachProducer = (rateInMsg * (durationSeconds + 1))
+                / numberOfProducersWithIndependentClients;
 
         // configure dispatch throttling rate
         BrokerService brokerService = pulsar.getBrokerService();
@@ -102,12 +103,12 @@ public class PublishRateLimiterOverconsumingTest extends BrokerTestBase {
         AtomicInteger lastCalculatedSecond = new AtomicInteger(0);
         List<Integer> collectedRatesForEachSecond = Collections.synchronizedList(new ArrayList<>());
 
-        // track actual consuming rate of messages per second
+        // rack actual consuming rate of messages per second
+        // (After aligning the first message, start counting whole seconds)
         Runnable rateTracker = () -> {
             long startTime = startTimeNanos.get();
             if (startTime == 0) {
-                startTimeNanos.compareAndSet(0, System.nanoTime());
-                startTime = startTimeNanos.get();
+                return;
             }
             long durationNanos = System.nanoTime() - startTime;
             int elapsedFullSeconds = (int) (durationNanos / 1e9);
@@ -124,10 +125,15 @@ public class PublishRateLimiterOverconsumingTest extends BrokerTestBase {
         ScheduledFuture<?> scheduledFuture = executor.scheduleAtFixedRate(rateTracker, 0, 500, TimeUnit.MILLISECONDS);
 
         // message listener implementation used for all consumers
+        // Set startTime when the first message arrives; then accumulate the counter
         MessageListener<Integer> messageListener = new MessageListener<>() {
             @Override
             public void received(Consumer<Integer> consumer, Message<Integer> msg) {
-                lastReceivedMessageTimeNanos.set(System.nanoTime());
+                long now = System.nanoTime();
+                if (startTimeNanos.get() == 0) {
+                    startTimeNanos.compareAndSet(0, now);
+                }
+                lastReceivedMessageTimeNanos.set(now);
                 currentSecondMessagesCount.incrementAndGet();
                 totalMessagesReceived.incrementAndGet();
                 consumer.acknowledgeAsync(msg);
@@ -233,33 +239,55 @@ public class PublishRateLimiterOverconsumingTest extends BrokerTestBase {
             });
         };
 
-        // wait for results
+        // Wait for all messages to be consumed
         Awaitility.await()
                 .atMost(Duration.ofSeconds(durationSeconds * 2))
                 .pollInterval(Duration.ofMillis(100))
-                .untilAsserted(
-                        () -> assertThat(collectedRatesForEachSecond).hasSizeGreaterThanOrEqualTo(durationSeconds));
+                .untilAsserted(() ->
+                        assertThat(totalMessagesReceived.get())
+                                .isEqualTo(numberOfProducersWithIndependentClients * numberOfMessagesForEachProducer));
+
+        // Collect per-second windows, and add the last half-second remainder
         List<Integer> collectedRatesSnapshot = new ArrayList<>(collectedRatesForEachSecond);
+        int tail = currentSecondMessagesCount.getAndSet(0);
+        if (tail > 0) {
+            collectedRatesSnapshot.add(tail);
+        }
         log.info("Collected rates for each second: {}", collectedRatesSnapshot);
-        long avgMsgRate =
-                totalMessagesReceived.get() / TimeUnit.NANOSECONDS.toSeconds(
-                        lastReceivedMessageTimeNanos.get() - startTimeNanos.get());
-        log.info("Average rate during the test run: {} msg/s", avgMsgRate);
+
+        // Calculate the average using second-by-second windows:
+        // Skip the first second, take up to durationSeconds windows.
+        int usable = Math.min(durationSeconds, Math.max(0, collectedRatesSnapshot.size() - 1));
+        double windowedAvg = (usable > 0)
+                ? collectedRatesSnapshot.subList(1, 1 + usable).stream().mapToInt(Integer::intValue).average().orElse(0)
+                : 0;
 
         assertSoftly(softly -> {
-            // check the rate during the test run
-            softly.assertThat(avgMsgRate).describedAs("average rate during the test run")
-                    // allow rate in 40% range
+            // Overall average (window mean, ±40%)
+            softly.assertThat(windowedAvg)
+                    .describedAs("windowed average rate during the test run")
                     .isCloseTo(rateInMsg, Percentage.withPercentage(40));
 
-            // check that rates were collected
-            // skip the first element as it might contain messages for first 2 seconds
-            softly.assertThat(collectedRatesSnapshot.subList(1, collectedRatesSnapshot.size() - 1))
-                    .describedAs("actual rates for each second")
-                    .allSatisfy(rates -> {
-                        assertThat(rates).describedAs("actual rate for each second")
+            // Per second (average of two adjacent seconds, skip first/last pairs, ±55%)
+            if (collectedRatesSnapshot.size() >= 4) {
+                // Starting from (1, 2), ending at (size-2, size-1)
+                for (int i = 2; i < collectedRatesSnapshot.size(); i++) {
+                    int avg2 = (collectedRatesSnapshot.get(i - 1) + collectedRatesSnapshot.get(i)) / 2;
+                    softly.assertThat(avg2)
+                            .describedAs("Average of second %d and %d", i, i + 1)
+                            .isCloseTo(rateInMsg, Percentage.withPercentage(55));
+                }
+            } else {
+                // Degenerates to: Skip head and tail with 50% tolerance (avoid false positives)
+                // when there are too few windows
+                if (collectedRatesSnapshot.size() > 2) {
+                    for (int i = 1; i < collectedRatesSnapshot.size() - 1; i++) {
+                        softly.assertThat(collectedRatesSnapshot.get(i))
+                                .describedAs("rate of second %d (fallback check)", i + 1)
                                 .isCloseTo(rateInMsg, Percentage.withPercentage(50));
-                    });
+                    }
+                }
+            }
         });
         scheduledFuture.cancel(true);
         producersClose.close();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #24846

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

The test PublishRateLimiterOverconsumingTest.testOverconsumingTokensWithBrokerPublishRateLimiter was intermittently failing under concurrent + batching scenarios. Failures were caused by:
- Warm-up and window misalignment: the first effective “second” often spans partial time across two real seconds, producing a very low first bucket and a very high second bucket (e.g., 24 and 1212).
- Bursty traffic: multiple independent producers with batching flushes lead to token bursts that concentrate into a single second.
- Average rate computed from total elapsed time: when bursts make the overall processing time shorter, avg = totalMessages/timeSinceStart becomes artificially high (e.g., 750 vs 500) even though the rate limiter is fine.

These issues are the same class as addressed for Dispatch in PR #24012. The test needs to measure rate more robustly to avoid false negatives while still detecting real regressions.

[org.apache.pulsar.broker.service.DispatchRateLimiterOverconsumingTest#testOverconsumingTokensWithBrokerDispatchRateLimiter](https://github.com/apache/pulsar/pull/24012/files#diff-6b2ae795e33ff0dbc7f8f00cad99f274132d36a2b95b733c5b2da0489f804f74R138-R284)


### Modifications

This change makes the test resilient by aligning measurement and smoothing per-second variability, following the approach used for Dispatch in PR #24012:

- Align measurement start to the first received message:
  - Start counting only after the first message arrives (set startTimeNanos in the messageListener). This removes the initial misalignment in the first bucket.

- Use windowed average for “overall average”:
  - Compute the test’s “average rate” from the collected per-second windows (skip the first second and take up to durationSeconds windows), instead of using totalMessages/elapsedTime, which is sensitive to overall time shortening due to bursts.
  - Assertion: the window-based average must be within ±40% of the configured rate.

- Use adjacent 2-second averages for per-second stability:
  - For each pair of adjacent seconds (skipping the head and tail pairs), assert that the mean of the two is within ±55% of the configured rate. This compensates for a low bucket followed by a high bucket caused by bursts or warm-up misalignment.
  - If there are too few windows (< 4), fall back to a single-second check (skip head and tail) with a ±50% tolerance to avoid spurious failures.

- Make wait condition robust:
  - Wait for all messages to be consumed rather than requiring a particular number of windows. This avoids waiting on windows in fast runs.

- Include trailing partial window:
  - Add the last partial bucket (if any) to the snapshot to not silently drop the tail.

- Non-functional/logging:
  - Keep the 500 ms polling for the rate tracker but only emit a per-second rate on full-second boundaries using lastCalculatedSecond.
  - Additional comments and logs for clarity.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/apache/pulsar/pull/24864

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->