### PR TITLE
[fix][broker] Wait for orphan schema ledger cleanup before retry

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/schema/BookkeeperSchemaStorage.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import lombok.CustomLog;
-import org.apache.bookkeeper.client.AsyncCallback;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
 import org.apache.bookkeeper.client.LedgerEntry;
@@ -366,33 +365,24 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
             SchemaLocator locator = new SchemaLocator();
             locator.setInfo().copyFrom(info);
             locator.addIndex().copyFrom(info);
-            CompletableFuture<Long> created = createSchemaLocator(
-                    getSchemaPath(schemaId), locator).thenApply(ignore -> 0L);
-
             // Step 3: Handle failure by cleaning up the orphan ledger
             // if concurrent schema creation caused a CAS conflict
-            return created.whenComplete((__, ex) -> {
-                if (ex == null) {
-                    return;
-                }
-                Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                log.warn()
-                        .attr("schemaId", schemaId)
-                        .attr("ledgerId", position.getLedgerId())
-                        .exception(cause)
-                        .log("Failed to create schema locator with position");
-                if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
-                    bookKeeper.asyncDeleteLedger(position.getLedgerId(), (rc, ctx) -> {
-                        if (rc != BKException.Code.OK) {
-                            log.warn()
-                                    .attr("schemaId", schemaId)
-                                    .attr("ledgerId", position.getLedgerId())
-                                    .attr("rc", rc)
-                                    .log("Failed to delete orphan ledger after schema locator creation failed");
+            return createSchemaLocator(getSchemaPath(schemaId), locator)
+                    .thenApply(ignore -> 0L)
+                    .exceptionallyCompose(ex -> {
+                        Throwable cause = FutureUtil.unwrapCompletionException(ex);
+                        log.warn()
+                                .attr("schemaId", schemaId)
+                                .attr("ledgerId", position.getLedgerId())
+                                .exception(cause)
+                                .log("Failed to create schema locator with position");
+                        if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
+                            return deleteLedgerAsync(schemaId, position.getLedgerId(),
+                                    "schema locator creation failed")
+                                    .thenCompose(__ -> FutureUtil.failedFuture(cause));
                         }
-                    }, null);
-                }
-            });
+                        return FutureUtil.failedFuture(cause);
+                    });
         });
     }
 
@@ -504,30 +494,46 @@ public class BookkeeperSchemaStorage implements SchemaStorage {
         return updateSchemaLocator(getSchemaPath(schemaId),
                 newLocator
                 , locatorEntry.version
-        ).thenApply(ignore -> nextVersion).whenComplete((__, ex) -> {
-            if (ex != null) {
-                Throwable cause = FutureUtil.unwrapCompletionException(ex);
-                log.warn()
-                        .attr("schemaId", schemaId)
-                        .attr("ledgerId", position.getLedgerId())
-                        .exception(cause)
-                        .log("Failed to update schema locator with position");
-                if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
-                    bookKeeper.asyncDeleteLedger(position.getLedgerId(), new AsyncCallback.DeleteCallback() {
-                        @Override
-                        public void deleteComplete(int rc, Object ctx) {
-                            if (rc != BKException.Code.OK) {
-                                log.warn()
-                                        .attr("schemaId", schemaId)
-                                        .attr("ledgerId", position.getLedgerId())
-                                        .attr("rc", rc)
-                                        .log("Failed to delete ledger after updating schema locator failed, rc");
-                            }
-                        }
-                    }, null);
-                }
+        ).thenApply(ignore -> nextVersion).exceptionallyCompose(ex -> {
+            Throwable cause = FutureUtil.unwrapCompletionException(ex);
+            log.warn()
+                    .attr("schemaId", schemaId)
+                    .attr("ledgerId", position.getLedgerId())
+                    .exception(cause)
+                    .log("Failed to update schema locator with position");
+            if (cause instanceof AlreadyExistsException || cause instanceof BadVersionException) {
+                return deleteLedgerAsync(schemaId, position.getLedgerId(),
+                        "schema locator update failed")
+                        .thenCompose(__ -> FutureUtil.failedFuture(cause));
             }
+            return FutureUtil.failedFuture(cause);
         });
+    }
+
+    private CompletableFuture<Void> deleteLedgerAsync(String schemaId, long ledgerId, String reason) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        try {
+            bookKeeper.asyncDeleteLedger(ledgerId, (rc, ctx) -> {
+                if (rc != BKException.Code.OK) {
+                    log.warn()
+                            .attr("schemaId", schemaId)
+                            .attr("ledgerId", ledgerId)
+                            .attr("rc", rc)
+                            .attr("reason", reason)
+                            .log("Failed to delete orphan schema ledger");
+                }
+                future.complete(null);
+            }, null);
+        } catch (Throwable t) {
+            log.warn()
+                    .attr("schemaId", schemaId)
+                    .attr("ledgerId", ledgerId)
+                    .attr("reason", reason)
+                    .exception(t)
+                    .log("Failed to trigger orphan schema ledger deletion");
+            future.complete(null);
+        }
+        return future;
     }
 
     @NonNull

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -55,6 +55,8 @@ import lombok.EqualsAndHashCode;
 import org.apache.avro.Schema.Parser;
 import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.PulsarMockBookKeeper;
+import org.apache.bookkeeper.client.PulsarMockLedgerHandle;
 import org.apache.bookkeeper.mledger.impl.LedgerMetadataUtils;
 import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
@@ -1394,48 +1396,96 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         final String topic = getTopicName(ns, "testConcurrentCreateSchemaNoOrphanLedger");
         final String schemaName = TopicName.get(topic).getSchemaName();
 
-        org.apache.bookkeeper.client.PulsarMockBookKeeper mockBk =
-                (org.apache.bookkeeper.client.PulsarMockBookKeeper) pulsar.getBookKeeperClient();
+        PulsarMockBookKeeper mockBk = (PulsarMockBookKeeper) pulsar.getBookKeeperClient();
 
         // Concurrently create producers with the same schema on a brand-new topic
         int concurrency = 16;
+        List<CompletableFuture<Producer<Schemas.PersonOne>>> producers = createProducersInParallel(
+                topic, Schema.AVRO(Schemas.PersonOne.class), concurrency);
+        try {
+            FutureUtil.waitForAll(producers).join();
+
+            // Verify only 1 schema version exists
+            assertEquals(admin.schemas().getAllSchemas(topic).size(), 1);
+
+            int schemaLedgerCount = countSchemaLedgers(mockBk, schemaName);
+            assertEquals(schemaLedgerCount, 1,
+                    "Expected exactly 1 schema ledger for the topic, but found "
+                            + schemaLedgerCount + ". Orphan ledgers were not cleaned up.");
+        } finally {
+            closeProducers(producers);
+        }
+    }
+
+    /**
+     * Test that concurrent compatible schema updates clean up ledgers created by requests
+     * that lose the schema locator CAS race.
+     */
+    @Test
+    public void testConcurrentUpdateSchemaNoOrphanLedger() throws Exception {
+        final String namespace = "test-namespace-" + randomName(16);
+        String ns = PUBLIC_TENANT + "/" + namespace;
+        admin.namespaces().createNamespace(ns, Sets.newHashSet(CLUSTER_NAME));
+
+        final String topic = getTopicName(ns, "testConcurrentUpdateSchemaNoOrphanLedger");
+        final String schemaName = TopicName.get(topic).getSchemaName();
+        PulsarMockBookKeeper mockBk = (PulsarMockBookKeeper) pulsar.getBookKeeperClient();
+
+        @Cleanup
+        Producer<Schemas.PersonOne> initialProducer = pulsarClient
+                .newProducer(Schema.AVRO(Schemas.PersonOne.class))
+                .topic(topic)
+                .create();
+        assertEquals(admin.schemas().getAllSchemas(topic).size(), 1);
+
+        int concurrency = 16;
+        List<CompletableFuture<Producer<Schemas.PersonThree>>> producers = createProducersInParallel(
+                topic, Schema.AVRO(Schemas.PersonThree.class), concurrency);
+        try {
+            FutureUtil.waitForAll(producers).join();
+
+            assertEquals(admin.schemas().getAllSchemas(topic).size(), 2);
+            int schemaLedgerCount = countSchemaLedgers(mockBk, schemaName);
+            assertEquals(schemaLedgerCount, 2,
+                    "Expected exactly 2 schema ledgers for the topic, but found "
+                            + schemaLedgerCount + ". Orphan ledgers were not cleaned up.");
+        } finally {
+            closeProducers(producers);
+        }
+    }
+
+    private <T> List<CompletableFuture<Producer<T>>> createProducersInParallel(
+            String topic, Schema<T> schema, int concurrency) throws InterruptedException {
         @Cleanup("shutdownNow")
         ExecutorService executor = Executors.newFixedThreadPool(concurrency);
-        List<CompletableFuture<Producer<Schemas.PersonOne>>> producers =
-                Collections.synchronizedList(new ArrayList<>(concurrency));
+        List<CompletableFuture<Producer<T>>> producers = Collections.synchronizedList(new ArrayList<>(concurrency));
         CountDownLatch latch = new CountDownLatch(concurrency);
         for (int i = 0; i < concurrency; i++) {
             executor.execute(() -> {
                 try {
-                    producers.add(pulsarClient.newProducer(Schema.AVRO(Schemas.PersonOne.class))
-                            .topic(topic).createAsync());
+                    producers.add(pulsarClient.newProducer(schema).topic(topic).createAsync());
                 } finally {
                     latch.countDown();
                 }
             });
         }
         latch.await();
-        FutureUtil.waitForAll(producers).join();
+        return producers;
+    }
 
-        // Verify only 1 schema version exists
-        assertEquals(admin.schemas().getAllSchemas(topic).size(), 1);
-
-        // Count surviving BK ledgers whose customMetadata "pulsar/schemaId" matches this topic's schemaName.
-        // If orphan ledgers were not cleaned up, there would be more than 1.
+    private int countSchemaLedgers(PulsarMockBookKeeper mockBk, String schemaName) {
         int schemaLedgerCount = 0;
-        for (org.apache.bookkeeper.client.PulsarMockLedgerHandle lh : mockBk.getLedgerMap().values()) {
+        for (PulsarMockLedgerHandle lh : mockBk.getLedgerMap().values()) {
             Map<String, byte[]> metadata = lh.getLedgerMetadata().getCustomMetadata();
             byte[] schemaIdBytes = metadata.get(LedgerMetadataUtils.METADATA_PROPERTY_SCHEMAID);
-            if (schemaIdBytes != null
-                    && schemaName.equals(new String(schemaIdBytes, java.nio.charset.StandardCharsets.UTF_8))) {
+            if (schemaIdBytes != null && schemaName.equals(new String(schemaIdBytes, StandardCharsets.UTF_8))) {
                 schemaLedgerCount++;
             }
         }
-        assertEquals(schemaLedgerCount, 1,
-                "Expected exactly 1 schema ledger for the topic, but found "
-                        + schemaLedgerCount + ". Orphan ledgers were not cleaned up.");
+        return schemaLedgerCount;
+    }
 
-        // Cleanup
+    private <T> void closeProducers(List<CompletableFuture<Producer<T>>> producers) {
         producers.forEach(p -> {
             try {
                 p.join().close();


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #25514

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

PR #25514 added orphan schema ledger cleanup when concurrent schema creation loses the schema locator CAS race. However, the cleanup used callback-style `asyncDeleteLedger` inside `whenComplete`, so the schema storage retry could continue before the BookKeeper delete callback completed.

This makes the no-orphan-ledger assertion timing-sensitive and weakens the cleanup guarantee exposed by schema creation. This PR waits for the orphan ledger delete callback before preserving the original CAS exception and letting the existing retry flow continue.

### Modifications

- Added a `deleteLedgerAsync` helper in `BookkeeperSchemaStorage` to wrap `bookKeeper.asyncDeleteLedger` with a `CompletableFuture`.
- Updated the initial schema creation CAS-failure path to wait for orphan ledger deletion before rethrowing the original `AlreadyExistsException` or `BadVersionException`.
- Updated the schema locator update CAS-failure path with the same cleanup behavior, keeping initial creation and update paths consistent.
- Kept deletion failure behavior compatible: delete failures are logged but do not fail schema creation.
- Refactored schema concurrency test helpers and added coverage for concurrent compatible schema updates to verify failed CAS attempts do not leave extra schema ledgers.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Matching PR in forked repository

PR in forked repository: https://github.com/apache/pulsar/pull/25579