### PR TITLE
[feat][cli] Add fault scenario controls to pulsar-perf

### DIFF
--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceConsumer.java
@@ -180,6 +180,15 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
     @Option(names = { "--histogram-file" }, description = "HdrHistogram output file")
     public String histogramFile = null;
 
+    @Option(names = {"--ack-mode"}, description = "Acknowledgement mode, valid options are: [ack, none]")
+    public AckMode ackMode = AckMode.ack;
+
+    @Option(names = {"--processing-delay-millis"}, description = "Delay before acknowledging each message")
+    public long processingDelayMillis = 0;
+
+    @Option(names = {"--ack-timeout-millis"}, description = "Ack timeout in millis. 0 disables ack timeout")
+    public long ackTimeoutMillis = 0;
+
     public PerformanceConsumer() {
         super("consume");
     }
@@ -206,6 +215,15 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
             } else {
                 throw new Exception("The size of subscriptions list should be equal to --num-subscriptions");
             }
+        }
+        if (this.ackMode == AckMode.none && this.isEnableTransaction) {
+            throw new Exception("--ack-mode none cannot be used with --txn-enable");
+        }
+        if (this.processingDelayMillis < 0) {
+            throw new Exception("--processing-delay-millis must be >= 0");
+        }
+        if (this.ackTimeoutMillis > 0 && this.ackTimeoutMillis <= 1000) {
+            throw new Exception("--ack-timeout-millis must be 0 or greater than 1000");
         }
     }
     @Override
@@ -296,7 +314,14 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                 recorder.recordValue(latencyMillis);
                 cumulativeRecorder.recordValue(latencyMillis);
             }
-            if (this.isEnableTransaction) {
+            if (this.processingDelayMillis > 0) {
+                try {
+                    Thread.sleep(this.processingDelayMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            if (this.ackMode == AckMode.ack && this.isEnableTransaction) {
                 try {
                     messageReceiveLimiter.acquire();
                 } catch (InterruptedException e){
@@ -314,7 +339,7 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                     }
                     return null;
                 });
-            } else {
+            } else if (this.ackMode == AckMode.ack) {
                 consumer.acknowledgeAsync(msg).thenRun(()->{
                             totalMessageAck.increment();
                             messageAck.increment();
@@ -397,29 +422,7 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
         };
 
         List<Future<Consumer<ByteBuffer>>> futures = new ArrayList<>();
-        ConsumerBuilder<ByteBuffer> consumerBuilder = pulsarClient.newConsumer(Schema.BYTEBUFFER) //
-                .messageListener(listener) //
-                .receiverQueueSize(this.receiverQueueSize) //
-                .maxTotalReceiverQueueSizeAcrossPartitions(this.maxTotalReceiverQueueSizeAcrossPartitions)
-                .acknowledgmentGroupTime(this.acknowledgmentsGroupingDelayMillis, TimeUnit.MILLISECONDS) //
-                .subscriptionType(this.subscriptionType)
-                .subscriptionInitialPosition(this.subscriptionInitialPosition)
-                .autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull)
-                .enableBatchIndexAcknowledgment(this.batchIndexAck)
-                .poolMessages(this.poolMessages)
-                .replicateSubscriptionState(this.replicatedSubscription)
-                .autoScaledReceiverQueueSizeEnabled(this.autoScaledReceiverQueueSize);
-        if (this.maxPendingChunkedMessage > 0) {
-            consumerBuilder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
-        }
-        if (this.expireTimeOfIncompleteChunkedMessageMs > 0) {
-            consumerBuilder.expireTimeOfIncompleteChunkedMessage(this.expireTimeOfIncompleteChunkedMessageMs,
-                    TimeUnit.MILLISECONDS);
-        }
-
-        if (isNotBlank(this.encKeyFile)) {
-            consumerBuilder.defaultCryptoKeyReader(this.encKeyFile);
-        }
+        ConsumerBuilder<ByteBuffer> consumerBuilder = createConsumerBuilder(pulsarClient, listener);
 
         for (int i = 0; i < this.numTopics; i++) {
             final TopicName topicName = TopicName.get(this.topics.get(i));
@@ -589,6 +592,37 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                 totalMessagesReceived.sum(), rate, throughput, rateAck, totalnumMessageAckFailed);
     }
 
+    ConsumerBuilder<ByteBuffer> createConsumerBuilder(PulsarClient pulsarClient,
+                                                      MessageListener<ByteBuffer> listener) {
+        ConsumerBuilder<ByteBuffer> consumerBuilder = pulsarClient.newConsumer(Schema.BYTEBUFFER) //
+                .messageListener(listener) //
+                .receiverQueueSize(this.receiverQueueSize) //
+                .maxTotalReceiverQueueSizeAcrossPartitions(this.maxTotalReceiverQueueSizeAcrossPartitions)
+                .acknowledgmentGroupTime(this.acknowledgmentsGroupingDelayMillis, TimeUnit.MILLISECONDS) //
+                .subscriptionType(this.subscriptionType)
+                .subscriptionInitialPosition(this.subscriptionInitialPosition)
+                .autoAckOldestChunkedMessageOnQueueFull(this.autoAckOldestChunkedMessageOnQueueFull)
+                .enableBatchIndexAcknowledgment(this.batchIndexAck)
+                .poolMessages(this.poolMessages)
+                .replicateSubscriptionState(this.replicatedSubscription)
+                .autoScaledReceiverQueueSizeEnabled(this.autoScaledReceiverQueueSize);
+        if (this.maxPendingChunkedMessage > 0) {
+            consumerBuilder.maxPendingChunkedMessage(this.maxPendingChunkedMessage);
+        }
+        if (this.expireTimeOfIncompleteChunkedMessageMs > 0) {
+            consumerBuilder.expireTimeOfIncompleteChunkedMessage(this.expireTimeOfIncompleteChunkedMessageMs,
+                    TimeUnit.MILLISECONDS);
+        }
+        if (this.ackTimeoutMillis > 0) {
+            consumerBuilder.ackTimeout(this.ackTimeoutMillis, TimeUnit.MILLISECONDS);
+        }
+
+        if (isNotBlank(this.encKeyFile)) {
+            consumerBuilder.defaultCryptoKeyReader(this.encKeyFile);
+        }
+        return consumerBuilder;
+    }
+
     private static void printAggregatedStats() {
         Histogram reportHistogram = cumulativeRecorder.getIntervalHistogram();
 
@@ -604,5 +638,9 @@ public class PerformanceConsumer extends PerformanceTopicListArguments{
                 reportHistogram.getValueAtPercentile(99.99),
                 reportHistogram.getValueAtPercentile(99.999),
                 reportHistogram.getMaxValue());
+    }
+
+    public enum AckMode {
+        ack, none
     }
 }

--- a/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
+++ b/pulsar-testclient/src/main/java/org/apache/pulsar/testclient/PerformanceProducer.java
@@ -214,6 +214,15 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
             + ", valid options are: [autoIncrement, random]", descriptionKey = "messageKeyGenerationMode")
     public String messageKeyGenerationMode = null;
 
+    @Option(names = {"--message-key"}, description = "Use a fixed key for all messages")
+    public String messageKey = null;
+
+    @Option(names = {"--message-routing-mode"}, description = "Message routing mode for partitioned topics")
+    public MessageRoutingMode messageRoutingMode = MessageRoutingMode.RoundRobinPartition;
+
+    @Option(names = {"--block-if-queue-full"}, arity = "1", description = "Block sends when the pending queue is full")
+    public boolean blockIfQueueFull = true;
+
     @Option(names = { "-am", "--access-mode" }, description = "Producer access mode")
     public ProducerAccessMode producerAccessMode = ProducerAccessMode.Shared;
 
@@ -436,6 +445,17 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
         super("produce");
     }
 
+    @Override
+    public void validate() throws Exception {
+        super.validate();
+        if (isNotBlank(this.messageKey) && isNotBlank(this.messageKeyGenerationMode)) {
+            throw new Exception("--message-key cannot be used with --message-key-generation-mode");
+        }
+        if (this.messageRoutingMode == MessageRoutingMode.CustomPartition) {
+            throw new Exception("--message-routing-mode CustomPartition is not supported by pulsar-perf");
+        }
+    }
+
     private static void executorShutdownNow(ExecutorService executor) {
         executor.shutdownNow();
         try {
@@ -470,8 +490,7 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
                 .compressionType(this.compression) //
                 .maxPendingMessages(this.maxOutstanding) //
                 .accessMode(this.producerAccessMode)
-                // enable round robin message routing if it is a partitioned topic
-                .messageRoutingMode(MessageRoutingMode.RoundRobinPartition);
+                .messageRoutingMode(this.messageRoutingMode);
         if (this.maxPendingMessagesAcrossPartitions > 0) {
             producerBuilder.maxPendingMessagesAcrossPartitions(this.maxPendingMessagesAcrossPartitions);
         }
@@ -494,8 +513,7 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
             producerBuilder.batchingMaxBytes(this.batchMaxBytes);
         }
 
-        // Block if queue is full else we will start seeing errors in sendAsync
-        producerBuilder.blockIfQueueFull(true);
+        producerBuilder.blockIfQueueFull(this.blockIfQueueFull);
 
         if (isNotBlank(this.encKeyName) && isNotBlank(this.encKeyFile)) {
             producerBuilder.addEncryptionKey(this.encKeyName);
@@ -648,8 +666,10 @@ public class PerformanceProducer extends PerformanceTopicListArguments{
                     if (this.setEventTime) {
                         messageBuilder.eventTime(System.currentTimeMillis());
                     }
-                    //generate msg key
-                    if (msgKeyMode == MessageKeyGenerationMode.random) {
+                    // Generate message key.
+                    if (isNotBlank(this.messageKey)) {
+                        messageBuilder.key(this.messageKey);
+                    } else if (msgKeyMode == MessageKeyGenerationMode.random) {
                         messageBuilder.key(String.valueOf(ThreadLocalRandom.current().nextInt()));
                     } else if (msgKeyMode == MessageKeyGenerationMode.autoIncrement) {
                         messageBuilder.key(String.valueOf(totalSent.get()));

--- a/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
+++ b/pulsar-testclient/src/test/java/org/apache/pulsar/testclient/PerformanceProducerTest.java
@@ -32,6 +32,7 @@ import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
 import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageRoutingMode;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.ProducerBuilderImpl;
@@ -179,6 +180,77 @@ public class PerformanceProducerTest extends MockedPulsarServiceBaseTest {
         ProducerBuilderImpl<byte[]> builder = (ProducerBuilderImpl<byte[]>) producer.createProducerBuilder(client,
                 producerId);
         Assert.assertFalse(builder.getConf().isBatchingEnabled());
+    }
+
+    @Test(timeOut = 20000)
+    public void testFixedMessageKey() throws Exception {
+        String argString = "%s -r 10 -u %s -m 5 --message-key hot-key";
+        String topic = testTopic + UUID.randomUUID();
+        String args = String.format(argString, topic, pulsar.getBrokerServiceUrl());
+        Thread thread = new Thread(() -> {
+            try {
+                PerformanceProducer producer = new PerformanceProducer();
+                producer.run(args.split(" "));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topic).subscriptionName("sub")
+                .subscriptionType(SubscriptionType.Shared).subscribe();
+
+        thread.start();
+
+        Message<byte[]> message = consumer.receive(15, TimeUnit.SECONDS);
+        assertNotNull(message);
+        Assert.assertEquals(message.getKey(), "hot-key");
+        consumer.acknowledge(message);
+
+        thread.interrupt();
+        thread.join();
+        consumer.close();
+    }
+
+    @Test
+    public void testMessageKeyCannotBeUsedWithMessageKeyGenerationMode() {
+        PerformanceProducer producer = new PerformanceProducer();
+        producer.topics = List.of(testTopic + UUID.randomUUID());
+        producer.messageKey = "hot-key";
+        producer.messageKeyGenerationMode = "random";
+
+        Assert.expectThrows(Exception.class, producer::validate);
+    }
+
+    @Test
+    public void testCustomMessageRoutingModeIsRejected() {
+        PerformanceProducer producer = new PerformanceProducer();
+        producer.topics = List.of(testTopic + UUID.randomUUID());
+        producer.messageRoutingMode = MessageRoutingMode.CustomPartition;
+
+        Assert.expectThrows(Exception.class, producer::validate);
+    }
+
+    @Test(timeOut = 20000)
+    public void testProducerFaultScenarioBuilderOptions() throws Exception {
+        String topic = testTopic + UUID.randomUUID();
+        PerformanceProducer producer = new PerformanceProducer();
+        producer.topics = List.of(topic);
+        producer.serviceURL = pulsar.getBrokerServiceUrl();
+
+        ClientBuilder clientBuilder = PerfClientUtils.createClientBuilderFromArguments(producer)
+                .enableTransaction(producer.isEnableTransaction);
+        @Cleanup
+        PulsarClient client = clientBuilder.build();
+        ProducerBuilderImpl<byte[]> defaultBuilder = (ProducerBuilderImpl<byte[]>) producer.createProducerBuilder(
+                client, 0);
+        Assert.assertEquals(defaultBuilder.getConf().getMessageRoutingMode(), MessageRoutingMode.RoundRobinPartition);
+        Assert.assertTrue(defaultBuilder.getConf().isBlockIfQueueFull());
+
+        producer.messageRoutingMode = MessageRoutingMode.SinglePartition;
+        producer.blockIfQueueFull = false;
+        ProducerBuilderImpl<byte[]> faultBuilder = (ProducerBuilderImpl<byte[]>) producer.createProducerBuilder(
+                client, 0);
+        Assert.assertEquals(faultBuilder.getConf().getMessageRoutingMode(), MessageRoutingMode.SinglePartition);
+        Assert.assertFalse(faultBuilder.getConf().isBlockIfQueueFull());
     }
 
     @Test(timeOut = 20000)


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

`pulsar-perf` is useful for generating producer, consumer, and reader traffic during performance tests and operational drills. However, it cannot currently model several common client-side production failure patterns directly, such as consumers that receive messages but do not ack, consumers that ack slowly after per-message processing delay, fixed-key partition hot spots, or producer pending-queue behavior that fails instead of blocking.

This PR adds these client-side controls to the existing `produce` and `consume` commands so operators can reproduce those scenarios with `pulsar-perf` instead of writing one-off custom clients. The default behavior remains unchanged.

### Modifications

- Add `--message-key` to `pulsar-perf produce` to publish all messages with a fixed key for key-skew and hot-partition simulations.
- Add `--message-routing-mode` to `pulsar-perf produce`, supporting `RoundRobinPartition` and `SinglePartition`, while rejecting unsupported `CustomPartition` usage from the CLI.
- Add `--block-if-queue-full` to `pulsar-perf produce`, defaulting to the existing blocking behavior and allowing failure-oriented pending-queue simulations when set to `false`.
- Add `--ack-mode`, `--processing-delay-millis`, and `--ack-timeout-millis` to `pulsar-perf consume` to support normal ack, no-ack, slow-ack, and ack-timeout redelivery simulations.
- Keep existing default producer routing, producer pending-queue behavior, and consumer ack behavior unchanged unless the new options are explicitly configured.
- Add tests for fixed-key production, producer option validation, producer builder defaults and overrides, consumer option validation, ack-timeout builder configuration, and no-ack unacked-message behavior.


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment